### PR TITLE
Minor docs changes for sequencing clarity

### DIFF
--- a/docs/source/getting-started/installation.rst
+++ b/docs/source/getting-started/installation.rst
@@ -49,8 +49,6 @@ or install from source:
   $ pip install ".[all]"
 
 
-Docker Installation
-===================
 
 .. note::
 

--- a/docs/source/getting-started/installation.rst
+++ b/docs/source/getting-started/installation.rst
@@ -3,6 +3,11 @@
 Installation
 ============
 
+.. note::
+
+    For Macs, macOS >= 10.15 is required to install SkyPilot. Apple Silicon-based devices (e.g. Apple M1) must run :code:`pip uninstall grpcio; conda install -c conda-forge grpcio=1.43.0` prior to installing SkyPilot.
+
+
 Install SkyPilot using pip:
 
 .. code-block:: console
@@ -28,6 +33,12 @@ If you only have access to certain clouds, use any combination of
 the pip extras above (e.g., :code:`"[aws,gcp]"`) to reduce the
 dependencies installed.
 
+.. note::
+
+    For Macs, macOS >= 10.15 is required to install SkyPilot. Apple Silicon-based devices (e.g. Apple M1) must run :code:`pip uninstall grpcio; conda install -c conda-forge grpcio=1.43.0` prior to installing SkyPilot.
+
+
+
 To get the latest features/updates, either install the nightly build:
 
 .. code-block:: console
@@ -42,10 +53,6 @@ or install from source:
   $ cd skypilot
   $ pip install ".[all]"
 
-
-.. note::
-
-    For Macs, macOS >= 10.15 is required to install SkyPilot. Apple Silicon-based devices (e.g. Apple M1) must run :code:`pip uninstall grpcio; conda install -c conda-forge grpcio=1.43.0` prior to installing SkyPilot.
 
 .. note::
 

--- a/docs/source/getting-started/installation.rst
+++ b/docs/source/getting-started/installation.rst
@@ -33,11 +33,6 @@ If you only have access to certain clouds, use any combination of
 the pip extras above (e.g., :code:`"[aws,gcp]"`) to reduce the
 dependencies installed.
 
-.. note::
-
-    For Macs, macOS >= 10.15 is required to install SkyPilot. Apple Silicon-based devices (e.g. Apple M1) must run :code:`pip uninstall grpcio; conda install -c conda-forge grpcio=1.43.0` prior to installing SkyPilot.
-
-
 
 To get the latest features/updates, either install the nightly build:
 

--- a/docs/source/getting-started/installation.rst
+++ b/docs/source/getting-started/installation.rst
@@ -1,6 +1,6 @@
 .. _installation:
 
-Local Installation
+Installation
 ==================
 
 .. note::

--- a/docs/source/getting-started/installation.rst
+++ b/docs/source/getting-started/installation.rst
@@ -59,7 +59,7 @@ Docker Installation
 .. _cloud-account-setup:
 
 Cloud account setup
-===================
+-------------------
 
 If you already have cloud access set up on your local machine, run ``sky check`` to :ref:`verify that SkyPilot can properly access your enabled clouds<verify-cloud-access>`.
 

--- a/docs/source/getting-started/installation.rst
+++ b/docs/source/getting-started/installation.rst
@@ -1,7 +1,7 @@
 .. _installation:
 
-Installation
-============
+Local Installation
+==================
 
 .. note::
 
@@ -54,6 +54,9 @@ or install from source:
   $ pip install ".[all]"
 
 
+Docker Installation
+===================
+
 .. note::
 
     As an alternative to installing SkyPilot on your laptop, we also provide a Docker image as a quick way to try out SkyPilot. See instructions below on running SkyPilot :ref:`in a container <docker-image>`.
@@ -61,7 +64,7 @@ or install from source:
 .. _cloud-account-setup:
 
 Cloud account setup
--------------------
+===================
 
 If you already have cloud access set up on your local machine, run ``sky check`` to :ref:`verify that SkyPilot can properly access your enabled clouds<verify-cloud-access>`.
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Put the warning about `conda install -c conda-forge grpcio=1.43.0` earlier so user hasn't already installed skypilot.
and highlight availability of a Docker installation

<!-- Describe the tests ran -->
None; documentation only.
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
